### PR TITLE
[fix] 山札から手札へカードが移動する処理を修正し、再実装した

### DIFF
--- a/KamisamaIntern/Assets/Image/CardImages/card_spine.png
+++ b/KamisamaIntern/Assets/Image/CardImages/card_spine.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ee2e32c75a30006a27ccfbdfade0e65c8652f1ade6982772e9ac7f595c70b51
+size 497

--- a/KamisamaIntern/Assets/Image/CardImages/card_spine.png.meta
+++ b/KamisamaIntern/Assets/Image/CardImages/card_spine.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: 0e6d240de79c368459a3a5f37dcb7fe4
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/KamisamaIntern/Assets/Image/CardImages/heavy_rain.png
+++ b/KamisamaIntern/Assets/Image/CardImages/heavy_rain.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b78713cae8cc79ed65c9e02118b555fa83c374506c3bcd3a0229ec86dc3f5026
+size 1873

--- a/KamisamaIntern/Assets/Image/CardImages/heavy_rain.png.meta
+++ b/KamisamaIntern/Assets/Image/CardImages/heavy_rain.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: 9c1f5874d3d0ff442b5c758ea9498fd0
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/KamisamaIntern/Assets/Image/CardImages/sun.png
+++ b/KamisamaIntern/Assets/Image/CardImages/sun.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c307e120c932589fa0f6a0060ce7fad9565d8b9027d125c002355bc2979d4eb9
+size 878

--- a/KamisamaIntern/Assets/Image/CardImages/sun.png.meta
+++ b/KamisamaIntern/Assets/Image/CardImages/sun.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: e2691034e215bde4385cd8b32938a762
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/KamisamaIntern/Assets/Image/CardImages/virus.png
+++ b/KamisamaIntern/Assets/Image/CardImages/virus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdc1ae9fd036361f991fb6208686b65436c99b97cdad713d1582bf965d19a841
+size 2749

--- a/KamisamaIntern/Assets/Image/CardImages/virus.png.meta
+++ b/KamisamaIntern/Assets/Image/CardImages/virus.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: 9cdbd66dcea27694db9bce503b3f8c03
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/KamisamaIntern/Assets/Image/CardImages/world_tree.png
+++ b/KamisamaIntern/Assets/Image/CardImages/world_tree.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c74c28efa979f0674be4640b42bb9107febae55602206e7e5bc62b5daf13145
+size 1742

--- a/KamisamaIntern/Assets/Image/CardImages/world_tree.png.meta
+++ b/KamisamaIntern/Assets/Image/CardImages/world_tree.png.meta
@@ -1,0 +1,98 @@
+fileFormatVersion: 2
+guid: d1d449819907a0447a86010599380587
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/AddCard.cs
+++ b/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/AddCard.cs
@@ -1,0 +1,147 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class AddCard : MonoBehaviour
+{
+    // 山札に生成されるカードのPrefab
+    [SerializeField] 
+    Image cardPrefab;
+
+    // 山札の枚数
+    [SerializeField] 
+    int allCardNum;
+
+    // 山札の何枚目が追加されたか
+    int nowCardNum = 0;
+
+    /* Card1~3のTransform */
+    [SerializeField] 
+    Transform card1Tf;
+    [SerializeField]
+    Transform card2Tf;
+    [SerializeField]
+    Transform card3Tf;
+    [SerializeField]
+    Transform deckTf;
+    /* ------------------- */
+
+    // カードの種類保持用の配列の初期化
+    [SerializeField]
+    private Sprite[] cardType;
+
+    // カードの種類数
+    [SerializeField]
+    private int cardTypeNum;
+
+    // 山札カード用のListの初期化
+    List<Image> allCards = new List<Image>();
+
+    // 始めに3枚配られたか
+    private bool isAddedFirst;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        // 山札を作る
+        for (int i = 0; i < allCardNum; i++)
+        {
+            Image c = Instantiate(cardPrefab, transform, false);
+
+            //Listにcardを追加していく
+            allCards.Add(c);
+        }
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        // ①始めに山札から手札に3枚選ぶ
+        if (CardController.isSimulatedOnMap == true && isAddedFirst == false)
+        {
+            AddedCardFirst();
+
+            isAddedFirst = true;
+            CardController.isSimulatedOnMap = false;
+        }
+        // ①以降、山札から1枚手札に追加されると手札から1枚廃棄される
+        else if(CardController.isSimulatedOnMap == true && isAddedFirst == true)
+        {
+            AddedCard();
+
+            CardController.isSimulatedOnMap = false;
+        }
+    }
+
+    // 始めに山札から手札に3枚セットされる
+    private void AddedCardFirst()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            // カードの効果をランダムに選ぶ
+            int randomDeckTypeNum = Random.Range(0, cardTypeNum);
+
+            // 選んだカードの効果画像を設定する
+            allCards[i].sprite = cardType[randomDeckTypeNum];
+        }
+
+        /* ----------------山札から手札3枚目への移動-------------- */
+        allCards[0].transform.SetParent(card3Tf);
+        allCards[0].transform.localPosition = Vector2.zero;
+        /* ------------------------------------------------------- */
+
+        /* ----------------山札から手札2枚目への移動-------------- */
+        allCards[1].transform.SetParent(card2Tf);
+        allCards[1].transform.localPosition = Vector2.zero;
+        /* ------------------------------------------------------- */
+
+        /* ----------------山札から手札1枚目への移動-------------- */
+        allCards[2].transform.SetParent(card1Tf);
+        allCards[2].transform.localPosition = Vector2.zero;
+        /* ------------------------------------------------------- */
+
+        nowCardNum = 3;
+    }
+
+    private void AddedCard()
+    {
+        if ((nowCardNum + 1) <= allCards.Count)
+        {
+            /* ----------------山札から手札1枚目への移動-------------- */
+
+            // カードの効果をランダムに選ぶ
+            int randomDeckTypeNum = Random.Range(0, cardTypeNum);
+            // 選んだカードの効果画像を設定する
+            allCards[nowCardNum].sprite = cardType[randomDeckTypeNum];
+
+            allCards[nowCardNum].transform.SetParent(card1Tf);
+            allCards[nowCardNum].transform.localPosition = Vector2.zero;
+
+            /* ------------------------------------------------------- */
+
+            /* ----------------手札1枚目から手札2枚目への移動-------------- */
+
+            allCards[nowCardNum - 1].transform.SetParent(card2Tf);
+            allCards[nowCardNum - 1].transform.localPosition = Vector2.zero;
+
+            /* ------------------------------------------------------- */
+
+            /* ----------------手札2枚目から手札3枚目への移動-------------- */
+
+            allCards[nowCardNum - 2].transform.SetParent(card3Tf);
+            allCards[nowCardNum - 2].transform.localPosition = Vector2.zero;
+
+            /* ------------------------------------------------------- */
+
+            /* ----------------手札3枚目から山札への移動-------------- */
+
+            allCards[nowCardNum - 3].transform.SetParent(deckTf);
+            allCards[nowCardNum - 3].transform.localPosition = Vector2.zero;
+
+            /* ------------------------------------------------------- */
+
+            nowCardNum++;
+        }
+    }
+}

--- a/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/AddCard.cs
+++ b/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/AddCard.cs
@@ -68,7 +68,7 @@ public class AddCard : MonoBehaviour
         // ‡@ˆÈ~ARD‚©‚ç1–‡èD‚É’Ç‰Á‚³‚ê‚é‚ÆèD‚©‚ç1–‡”pŠü‚³‚ê‚é
         else if(CardController.isSimulatedOnMap == true && isAddedFirst == true)
         {
-            AddedCard();
+            AddAndDiscardCard();
 
             CardController.isSimulatedOnMap = false;
         }
@@ -104,7 +104,7 @@ public class AddCard : MonoBehaviour
         nowCardNum = 3;
     }
 
-    private void AddedCard()
+    private void AddAndDiscardCard()
     {
         if ((nowCardNum + 1) <= allCards.Count)
         {

--- a/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/AddCard.cs.meta
+++ b/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/AddCard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95a566964e718f143ba6142dfcb5cbb5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/CardController.cs
+++ b/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/CardController.cs
@@ -8,7 +8,7 @@ public class CardController : MonoBehaviour
     public static bool canChooseCard = false;
 
     // シミュレートターン
-    private bool isSimulatedOnMap;
+    public static bool isSimulatedOnMap = true;
 
     // カードが選択されたかどうか
     private bool isChoseCard = false;

--- a/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/CardController.cs
+++ b/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/CardController.cs
@@ -55,9 +55,7 @@ public class CardController : MonoBehaviour
     // カードが1枚追加され、1枚破棄される処理
     private void AddCard()
     {
-        Debug.Log("カードが1枚追加される");
-
-        /* カードが一枚追加され、1枚破棄される処理 */
+        Debug.Log("カードが追加される");
 
         Invoke("AllowChooseCard", timeOfSimulation);
     }
@@ -65,7 +63,7 @@ public class CardController : MonoBehaviour
     // カード選択可能時間に行われる処理
     private void AllowChooseCard()
     {
-        isSimulatedOnMap = false;
+        isSimulatedOnMap = false; // ここで、AddCardスクリプトでAddAndDiscardCard関数が実行される
         canChooseCard = true;
 
         Debug.Log("カードを選択するたいむ");

--- a/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/DeckController.cs
+++ b/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/DeckController.cs
@@ -13,10 +13,6 @@ public class DeckController : MonoBehaviour
     [SerializeField] 
     int deckCardNum;
 
-    // カードが追加され、入れ替わるまでの時間間隔
-    [SerializeField]
-    int timeOfSwappingCards;
-
     // 山札の何枚目が追加されたか
     int nowCardNum = 0;
 
@@ -53,20 +49,22 @@ public class DeckController : MonoBehaviour
             //Listにcardを追加していく
             deckCards.Add(c);
         }
-
-        //MoveCardsを0秒後に呼び出し、以降は{timeOfSwappingCards}秒毎に実行
-        InvokeRepeating(nameof(MoveCards), 0f, timeOfSwappingCards);
     }
 
     // Update is called once per frame
     void Update()
     {
+        if (CardController.isSimulatedOnMap == true)
+        {
+            MoveCards();
 
+            CardController.isSimulatedOnMap = false;
+        }
     }
 
-    void MoveCards()
+    public void MoveCards()
     {
-        Debug.Log("カードが追加された");
+        //Debug.Log("カードが追加された");
 
         if ((nowCardNum+1) <= deckCards.Count)
         {
@@ -81,14 +79,28 @@ public class DeckController : MonoBehaviour
                     deckCards[i].sprite = deckType[randomDeckTypeNum2];
                 }
 
+                /*
                 // 山札から手札の3枚目に1枚移動
                 deckCards[0].transform.DOMove(card3Tf.position, 1.0f)
                     .SetEase(Ease.InCirc)
                     .OnComplete(() => deckCards[0].transform.SetParent(card3Tf));
+                */
+                // 山札から手札の3枚目に1枚移動
+                //カードを別の山の子要素にする
+                deckCards[0].transform.SetParent(card3Tf);
+                //カードのlocalPositionを0にする
+                deckCards[0].transform.localPosition = Vector2.zero;
+
+                /*
                 // 山札から手札の2枚目に1枚移動
                 deckCards[1].transform.DOMove(card2Tf.position, 1.0f)
                     .SetEase(Ease.InCirc)
                     .OnComplete(() => deckCards[1].transform.SetParent(card2Tf));
+                */
+                // 山札から手札の2枚目に1枚移動
+                deckCards[1].transform.SetParent(card2Tf);
+                //カードのlocalPositionを0にする
+                deckCards[1].transform.localPosition = Vector2.zero;
 
                 nowCardNum += 2;
             }
@@ -99,25 +111,47 @@ public class DeckController : MonoBehaviour
             // 選んだカードの効果画像を設定する
             deckCards[nowCardNum].sprite = deckType[randomDeckTypeNum];
 
+            /*
             // 山札から手札の1枚目に1枚移動
             deckCards[nowCardNum].transform.DOMove(card1Tf.position, 1.0f)
                 .SetEase(Ease.InCirc)
                 .OnComplete(() => deckCards[nowCardNum].transform.SetParent(card1Tf));
+            */
+
+            // 山札から手札の1枚目に1枚移動
+            deckCards[nowCardNum].transform.SetParent(card1Tf);
+            //カードのlocalPositionを0にする
+            deckCards[nowCardNum].transform.localPosition = Vector2.zero;
+
 
             if (nowCardNum > 0)
             {
+                /*
                 // 手札1枚目から手札2枚目へカードが移動
                 deckCards[nowCardNum - 1].transform.DOMove(card2Tf.position, 1.0f)
                     .SetEase(Ease.InCirc)
                     .OnComplete(() => deckCards[nowCardNum - 1].transform.SetParent(card2Tf));
+                */
+
+                // 手札1枚目から手札の2枚目に1枚移動
+                deckCards[nowCardNum - 1].transform.SetParent(card2Tf);
+                //カードのlocalPositionを0にする
+                deckCards[nowCardNum - 1].transform.localPosition = Vector2.zero;
             }
             
             if (nowCardNum > 1)
             {
+                /*
                 // 手札2枚目から手札3枚目へカードが移動
                 deckCards[nowCardNum - 2].transform.DOMove(card3Tf.position, 1.0f)
                     .SetEase(Ease.InCirc)
                     .OnComplete(() => deckCards[nowCardNum - 2].transform.SetParent(card3Tf));
+                */
+
+                // 手札2枚目から手札の3枚目に1枚移動
+                deckCards[nowCardNum - 2].transform.SetParent(card3Tf);
+                //カードのlocalPositionを0にする
+                deckCards[nowCardNum].transform.localPosition = Vector2.zero;
             }
 
             if (nowCardNum > 2)

--- a/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/RenewalCardScene.unity
+++ b/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/RenewalCardScene.unity
@@ -8043,7 +8043,11 @@ MonoBehaviour:
   - {fileID: 21300000, guid: 822a5b3cbd3aa7c4ab8394f7944e057f, type: 3}
   - {fileID: 21300000, guid: c6a6bfa9a3bbc3a4297c2e3e8ffeb419, type: 3}
   - {fileID: 21300000, guid: 53fd05311b390b246819d56fcb84c47b, type: 3}
-  cardTypeNum: 6
+  - {fileID: 21300000, guid: 9c1f5874d3d0ff442b5c758ea9498fd0, type: 3}
+  - {fileID: 21300000, guid: e2691034e215bde4385cd8b32938a762, type: 3}
+  - {fileID: 21300000, guid: d1d449819907a0447a86010599380587, type: 3}
+  - {fileID: 21300000, guid: 9cdbd66dcea27694db9bce503b3f8c03, type: 3}
+  cardTypeNum: 10
 --- !u!1 &1288851740
 GameObject:
   m_ObjectHideFlags: 0

--- a/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/RenewalCardScene.unity
+++ b/KamisamaIntern/Assets/Suebayashi_Folder/CardOption/RenewalCardScene.unity
@@ -364,6 +364,11 @@ RectTransform:
   m_Children:
   - {fileID: 1516719141}
   - {fileID: 1355597126}
+  - {fileID: 1025742929}
+  - {fileID: 233630405}
+  - {fileID: 1519476382}
+  - {fileID: 1288653465}
+  - {fileID: 1172223030}
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1475,6 +1480,82 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &233630404
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 233630405}
+  - component: {fileID: 233630407}
+  - component: {fileID: 233630406}
+  m_Layer: 0
+  m_Name: MyCard2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &233630405
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 233630404}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.96, y: 0.96, z: 2.3999999}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 85747711}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -182.40002, y: -422.40005}
+  m_SizeDelta: {x: -1745.4736, y: -851.2717}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &233630406
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 233630404}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &233630407
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 233630404}
+  m_CullTransparentMesh: 1
 --- !u!1 &242047489
 GameObject:
   m_ObjectHideFlags: 0
@@ -6459,6 +6540,82 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1068338127916109497, guid: 9b02fdac327dea9478add4212a91c21d, type: 3}
   m_PrefabInstance: {fileID: 1012422176}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1025742928
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1025742929}
+  - component: {fileID: 1025742931}
+  - component: {fileID: 1025742930}
+  m_Layer: 0
+  m_Name: MyCard1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1025742929
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1025742928}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.96, y: 0.96, z: 2.3999999}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 85747711}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -457.67996, y: -422.40005}
+  m_SizeDelta: {x: -1745.4736, y: -851.2717}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1025742930
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1025742928}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1025742931
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1025742928}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1066688190
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7149,6 +7306,82 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &1172223029
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1172223030}
+  - component: {fileID: 1172223032}
+  - component: {fileID: 1172223031}
+  m_Layer: 5
+  m_Name: HideCardsPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1172223030
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1172223029}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.96, y: 0.96, z: 2.3999999}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 85747711}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -782.4, y: -422.40005}
+  m_SizeDelta: {x: -1745.4736, y: -851.2717}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1172223031
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1172223029}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 0e6d240de79c368459a3a5f37dcb7fe4, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1172223032
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1172223029}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1177265299
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7708,6 +7941,109 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8475477297375066065, guid: 8c60719b50b80d849bc3ac38e9644b59, type: 3}
   m_PrefabInstance: {fileID: 1256174999}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1288653464
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1288653465}
+  - component: {fileID: 1288653468}
+  - component: {fileID: 1288653467}
+  - component: {fileID: 1288653469}
+  m_Layer: 5
+  m_Name: DeckCards
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1288653465
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1288653464}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.96, y: 0.96, z: 2.3999999}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 85747711}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -782.4, y: -422.40005}
+  m_SizeDelta: {x: -1745.4736, y: -851.2717}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1288653467
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1288653464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1288653468
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1288653464}
+  m_CullTransparentMesh: 1
+--- !u!114 &1288653469
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1288653464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95a566964e718f143ba6142dfcb5cbb5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cardPrefab: {fileID: 7878020609961320746, guid: 0188766e67b075848ba97010985c7076, type: 3}
+  allCardNum: 20
+  card1Tf: {fileID: 1025742929}
+  card2Tf: {fileID: 233630405}
+  card3Tf: {fileID: 1519476382}
+  deckTf: {fileID: 1288653465}
+  cardType:
+  - {fileID: 21300000, guid: 1c3d0204c173e264a900f5f166d29684, type: 3}
+  - {fileID: 21300000, guid: a9f4b3666b504e24291f0714ba723e07, type: 3}
+  - {fileID: 21300000, guid: b5bbe5edee385454c9775240fbcabd18, type: 3}
+  - {fileID: 21300000, guid: 822a5b3cbd3aa7c4ab8394f7944e057f, type: 3}
+  - {fileID: 21300000, guid: c6a6bfa9a3bbc3a4297c2e3e8ffeb419, type: 3}
+  - {fileID: 21300000, guid: 53fd05311b390b246819d56fcb84c47b, type: 3}
+  cardTypeNum: 6
 --- !u!1 &1288851740
 GameObject:
   m_ObjectHideFlags: 0
@@ -8338,7 +8674,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 63, y: -474}
+  m_AnchoredPosition: {x: 592, y: -318}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1355597127
@@ -9103,6 +9439,82 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1516719140}
+  m_CullTransparentMesh: 1
+--- !u!1 &1519476381
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1519476382}
+  - component: {fileID: 1519476384}
+  - component: {fileID: 1519476383}
+  m_Layer: 0
+  m_Name: MyCard3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1519476382
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519476381}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.96, y: 0.96, z: 2.3999999}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 85747711}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 93.599976, y: -422.40005}
+  m_SizeDelta: {x: -1745.4736, y: -851.2717}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1519476383
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519476381}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1519476384
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519476381}
   m_CullTransparentMesh: 1
 --- !u!1 &1534556811
 GameObject:


### PR DESCRIPTION
シーン「RenewalCardScene」にて、

実行した瞬間、
- [ ] 始めに山札から手札へ3枚のカードがランダムで配布される

デバッグで「カードを選ぶタイム」になった際、
- [ ] 10秒間何も選択しなければカードが1枚追加され、シミュレートへ移行
- [ ] クリックを押すとカードが1枚追加され、シミュレートへ移行